### PR TITLE
some updates and tests

### DIFF
--- a/Entitas.Generic/Core/Entity_ClassMethods.cs
+++ b/Entitas.Generic/Core/Entity_ClassMethods.cs
@@ -43,6 +43,14 @@
             ReplaceComponent(index, comp);
         }
 
+        public TComp Init<TComp>() where TComp : class, Scope<TScope>, ICompData, IComponent, new()
+        {
+          var index = Lookup<TScope, TComp>.Id;
+          var compData = (TComp) CreateComponent(index, typeof(TComp));
+          ReplaceComponent(index, compData);
+          return compData;
+        }
+
         public void Flag<TComp>(bool flag) where TComp : class, Scope<TScope>, ICompFlag, IComponent, new()
         {
             var index = Lookup<TScope, TComp>.Id;
@@ -80,6 +88,13 @@
         public bool HasIComponent<TComp>() where TComp : class, Scope<TScope>, IComponent
         {
             return HasComponent(Lookup<TScope, TComp>.Id);
+        }
+        
+        public void RemoveIfExists<TComp>()where TComp : class, Scope<TScope>, ICompData, IComponent
+        {
+          if (Has<TComp>()) {
+            RemoveComponent(Lookup<TScope, TComp>.Id);
+          }
         }
     }
 }

--- a/Entitas.Generic/Core/StructComponent.cs
+++ b/Entitas.Generic/Core/StructComponent.cs
@@ -4,10 +4,9 @@ public class StructComponent<TData> : IComponent where TData : struct
 {
 	public TData Data;
 
-	// Consider removing ToString here and deal with string formatting in concrete places
-	public override string ToString()
-	{
-		return typeof(TData).ToGenericTypeString(  );
-	}
+	public override string ToString() 
+  {
+    return Data.ToString();
+  }
 }
 }

--- a/README.md
+++ b/README.md
@@ -248,9 +248,16 @@ public static class EntIndex
 
 // Step 2. Add EntityIndex during initialization stage
 var context = contexts.Get<Game>( );
+
+// Step2.1 for Class Component
 context.AddEntityIndex( EntIndex.B
     , context.GetGroup( Matcher<Game, B>.I )
     , ( e, c ) => ( (B)c ).Value );
+
+// OR Step2.2 for Struct Component
+context.AddEntityIndex( EntIndex.B
+    , context.GetGroup( Matcher<Game, B>.I )
+    , ( e, c ) => ( (StructComponent<B>) c).Data.value );
 
 
 // Step 3. Get entities at runtime

--- a/Tests/Tests/Tests.csproj
+++ b/Tests/Tests/Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <LangVersion>4</LangVersion>
   </PropertyGroup>

--- a/Tests/Tests/Tests/Core/TestClasses.cs
+++ b/Tests/Tests/Tests/Core/TestClasses.cs
@@ -98,6 +98,19 @@ namespace Tests
 	{
 		public				Single					Value;
 	}
+  
+  public sealed class TestComp_InitSet
+      : IComponent
+          , ICompData
+          , Scope<ScopeA>
+  {
+    public				Single					Value;
+    
+    public TestComp_InitSet Set(float value) {
+      Value = value;
+      return this;
+    }
+  }
 
 	public sealed class TestFlagA : IComponent, ICompFlag, Scope<ScopeA>, IEvent_Self<ScopeA,TestFlagA>
 	{ }

--- a/Tests/Tests/Tests/Core/describe_Entity_ClassMethods.cs
+++ b/Tests/Tests/Tests/Core/describe_Entity_ClassMethods.cs
@@ -122,6 +122,46 @@ namespace Tests
 				entity.Has<TestComp_CreateApply_A>(  ).should_be_true(  );
 				entity.Get<TestComp_CreateApply_A>(  ).should_be_same( comp );
 			};
+      
+      it["Init (Create or Replace) component"] = ()=>
+      {
+        // given
+        var entity = _contexts.Get<ScopeA>().CreateEntity();
+
+        // when
+        var comp1 = entity.Init<TestComp_InitSet>();
+
+        // then - entity has component at once after Init
+        comp1.Value.should_be(0f);
+        entity.Has<TestComp_InitSet>().should_be_true();
+
+        // when Remove updated component and Init it again
+        comp1.Value = 1f;
+        entity.Remove<TestComp_InitSet>();
+        var comp2 = entity.Init<TestComp_InitSet>();
+
+        // then
+        entity.Has<TestComp_InitSet>().should_be_true();
+        // ... it is the same component as comp1, it was taken from components pool
+        entity.Get<TestComp_InitSet>().should_be_same(comp1);
+        entity.Get<TestComp_InitSet>().should_be_same(comp2);
+        // ... and its value is not reset after Init !
+        // users have to remember to call .Set method
+        comp2.Value.should_be(1);
+      };
+      
+      it["Init-Set (Create or Replace + Set) component data"] = ()=>
+      {
+        // given
+        var entity = _contexts.Get<ScopeA>().CreateEntity();
+
+        // when
+        var comp1 = entity.Init<TestComp_InitSet>().Set(1);
+
+        // then
+        entity.Has<TestComp_InitSet>().should_be_true();
+        comp1.Value.should_be(1);
+      };
 
 			it["flag, is"] = ()=>
 			{

--- a/Tests/Tests_Performance/MemoryHelper.cs
+++ b/Tests/Tests_Performance/MemoryHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Tests {
+  public class MemoryHelper {
+    public static List<long> GetMemoryStats(Process process) {
+      return new List<long> {
+          GC.GetTotalMemory(false),
+          process.PeakVirtualMemorySize64,
+          process.PeakPagedMemorySize64,
+          process.VirtualMemorySize64,
+          process.PrivateMemorySize64,
+          process.PagedMemorySize64,
+          process.NonpagedSystemMemorySize64,
+          process.PagedSystemMemorySize64,
+      };
+    }
+
+    public static string GetMemoryAllStatsString(Process process) {
+      return String.Join(", ", GetMemoryStats(process));
+    }
+  }
+}

--- a/Tests/Tests_Performance/PerformanceTestsRunner.cs
+++ b/Tests/Tests_Performance/PerformanceTestsRunner.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics;
+using Tests;
 
 public static class PerformanceTestRunner
 {
@@ -8,12 +10,17 @@ public static class PerformanceTestRunner
 		_stopwatch = new Stopwatch();
 	}
 
-	public static long Run(IPerformanceTest test) {
+	public static Tuple<long,long> Run(IPerformanceTest test) {
 		test.Before();
 		_stopwatch.Reset();
-		_stopwatch.Start();
+    var currentProcess = Process.GetCurrentProcess();
+    var bytesBefore = MemoryHelper.GetMemoryStats(currentProcess);
+    _stopwatch.Start();
 		test.Run();
 		_stopwatch.Stop();
-		return _stopwatch.ElapsedMilliseconds;
+    var bytesAfter = MemoryHelper.GetMemoryStats(currentProcess);
+    // only GC memory shows some differences...
+    long memoryDiff = bytesAfter[0] - bytesBefore[0];
+    return new Tuple<long, long>(_stopwatch.ElapsedMilliseconds, memoryDiff);
 	}
 }

--- a/Tests/Tests_Performance/Program.cs
+++ b/Tests/Tests_Performance/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Runtime;
 using System.Threading;
 using Entitas.Generic;
 
@@ -6,15 +8,47 @@ namespace Tests
 {
 internal class Program
 {
-	public static void Main(string[] args)
+  private static Process currentProcess;
+
+  public static void Main(string[] args)
 	{
 		Console.WriteLine("Running performance tests...");
+    currentProcess = Process.GetCurrentProcess();
+    Console.WriteLine($"memory at process start: {MemoryHelper.GetMemoryAllStatsString(currentProcess)}");
+    
 		Lookup_ScopeManager.RegisterAll();
 
 		Thread.Sleep(1500); // why?
 
+    GCSettings.LatencyMode = GCLatencyMode.LowLatency;
+    if (!GC.TryStartNoGCRegion(0)) {
+      throw new Exception("can't start NoGCRegion");
+    }
+    
+    Console.WriteLine($"memory before tests: {MemoryHelper.GetMemoryAllStatsString(currentProcess)}");
+
+    // 1 exclude component-data-init time from test
 		run<Entity_AddRemove_CompData_Class>();
+    // 2 include component-data-init into test
+    // (results can be compared with tests 3 4 5 and 11)
+		run<Entity_AddRemove_CompData_Class_AddNewInstance>();
+    // 3 replace component data init by Cache.I.Set
+    // (results can be compared with tests 2 4 5 and 11)
+		run<Entity_AddRemove_CompData_Class_SetUsingCache>();
+    // 4 Create-Apply workflow
+    // (results can be compared with tests 2, 3 5  and 11)
+		run<Entity_AddRemove_CompData_Class_CreateSetApply>();
+    // 5 InitSet is a syntax-variant of Create-Apply
+    // (results can be compared with tests 2, 3 4 and 11 but especially with 4)
+    run<Entity_AddRemove_CompData_Class_InitSet>();
+    // 3.2 repeat test#3 to double check stats accuracy
+    run<Entity_AddRemove_CompData_Class_SetUsingCache>();
+    
+    // 10 base struct Add test
 		run<Entity_AddRemove_CompData_Struct>();
+    // 11 is like 10 but component initialization is included into test
+    // so results can be compared with tests 2-5
+		run<Entity_AddRemove_CompData_Struct_IncludeInit>();
 		run<Entity_AddRemove_CompData_Class_WithGroups>();
 		run<Entity_AddRemove_CompData_Struct_WithGroups>();
 		run<Entity_Replace_CompData_Class_WithGroups>();
@@ -29,15 +63,26 @@ internal class Program
 		run<Entity_Flag_CompFlag>(  );
 		run<Entity_Is_CompFlag>(  );
 
-		// Console.WriteLine("\nPress any key...");
-		// Console.Read();
-	}
+    Console.WriteLine($"memory after tests: {MemoryHelper.GetMemoryAllStatsString(currentProcess)}");
+    
+    try {
+      GC.EndNoGCRegion();
+    } catch (System.InvalidOperationException e) {
+      Console.WriteLine("\nMemory validation needs to be improved... " +
+                        "\nProcess had to clean memory while in NoGC mode" +
+                        "\nNegative memory diffs indicate that");
+      throw;
+    }
 
-	//Running performance tests...
+    // Console.WriteLine("\nPress any key...");
+    // Console.Read();
+  }
+
+  //Running performance tests...
 
 	static void run<T>() where T : IPerformanceTest, new()
 	{
-		Thread.Sleep(100);
+		Thread.Sleep(500);
 		if (typeof(T) == typeof(EmptyTest))
 		{
 			Console.WriteLine(string.Empty);
@@ -47,8 +92,10 @@ internal class Program
 		Console.Write( test.Iterations.ToString( "e0" ) + " " + (typeof(T) + ": ").PadRight(60));
 		// For more reliable results, run before
 		PerformanceTestRunner.Run(test);
-		var ms = PerformanceTestRunner.Run(new T());
-		Console.WriteLine(ms + " ms");
+		Tuple<long,long> msAndMemory = PerformanceTestRunner.Run(new T());
+    Console.Write((msAndMemory.Item1 + " ms").PadRight(10));
+    Console.Write(("mem.DIFF " +msAndMemory.Item2 + " bytes").PadRight(30));
+    Console.WriteLine("mem.ALL " + MemoryHelper.GetMemoryAllStatsString(currentProcess) + " bytes");
 	}
 }
 }

--- a/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_AddNewInstance.cs
+++ b/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_AddNewInstance.cs
@@ -1,0 +1,28 @@
+﻿using Entitas.Generic;
+
+#pragma warning disable
+public class Entity_AddRemove_CompData_Class_AddNewInstance : IPerformanceTest
+{
+	private const			int						n						= 10000000;
+	private					Entity<TestScope1>		_ent;
+	private					TestCompA_Scope1		_testCompAScope1;
+	public					int						Iterations				=> n;
+
+	public					void					Before					(  )
+	{
+		var contexts				= new Contexts(  );
+		contexts.AddScopedContexts(  );
+
+		var context					= contexts.Get<TestScope1>();
+		_ent						= context.CreateEntity();
+	}
+
+	public					void					Run						(  )
+	{
+		for ( var i = 0; i < n; i++ )
+		{
+			_ent.Add( new TestCompA_Scope1( 5 ) );
+			_ent.Remove<TestCompA_Scope1>(  );
+		}
+	}
+}

--- a/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_CreateSetApply.cs
+++ b/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_CreateSetApply.cs
@@ -1,0 +1,28 @@
+﻿using Entitas.Generic;
+
+#pragma warning disable
+public class Entity_AddRemove_CompData_Class_CreateSetApply : IPerformanceTest
+{
+	private const			int						n						= 10000000;
+	private					Entity<TestScope1>		_ent;
+	private					TestCompA_Scope1		_testCompAScope1;
+	public					int						Iterations				=> n;
+
+	public					void					Before					(  )
+	{
+		var contexts				= new Contexts(  );
+		contexts.AddScopedContexts(  );
+
+		var context					= contexts.Get<TestScope1>();
+		_ent						= context.CreateEntity();
+	}
+
+	public					void					Run						(  )
+	{
+		for ( var i = 0; i < n; i++ )
+		{
+      _ent.Apply(_ent.Create<TestCompA_Scope1>().Set(5));
+			_ent.Remove<TestCompA_Scope1>(  );
+		}
+	}
+}

--- a/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_InitSet.cs
+++ b/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_InitSet.cs
@@ -1,0 +1,28 @@
+﻿using Entitas.Generic;
+
+#pragma warning disable
+public class Entity_AddRemove_CompData_Class_InitSet : IPerformanceTest
+{
+	private const			int						n						= 10000000;
+	private					Entity<TestScope1>		_ent;
+	private					TestCompA_Scope1		_testCompAScope1;
+	public					int						Iterations				=> n;
+
+	public					void					Before					(  )
+	{
+		var contexts				= new Contexts(  );
+		contexts.AddScopedContexts(  );
+
+		var context					= contexts.Get<TestScope1>();
+		_ent						= context.CreateEntity();
+	}
+
+	public					void					Run						(  )
+	{
+		for ( var i = 0; i < n; i++ )
+		{
+      _ent.Init<TestCompA_Scope1>().Set(5);
+			_ent.Remove<TestCompA_Scope1>(  );
+		}
+	}
+}

--- a/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_SetUsingCache.cs
+++ b/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Class_SetUsingCache.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Entitas.Generic;
+
+#pragma warning disable
+public class Entity_AddRemove_CompData_Class_SetUsingCache : IPerformanceTest
+{
+	private const			int						n						= 10000000;
+	private					Entity<TestScope1>		_ent;
+	private					TestCompA_Scope1		_testCompAScope1;
+	public					int						Iterations				=> n;
+
+	public					void					Before					(  )
+	{
+		var contexts				= new Contexts(  );
+		contexts.AddScopedContexts(  );
+
+		var context					= contexts.Get<TestScope1>();
+		_ent						= context.CreateEntity();
+	}
+
+	public					void					Run						(  )
+	{
+		for ( var i = 0; i < n; i++ )
+		{
+      _ent.Add(Cache<TestCompA_Scope1>.I.Set(5));
+			_ent.Remove<TestCompA_Scope1>(  );
+		}
+	}
+}

--- a/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Struct_IncludeInit.cs
+++ b/Tests/Tests_Performance/Sources/Entity/Entity_AddRemove_CompData_Struct_IncludeInit.cs
@@ -1,0 +1,27 @@
+﻿using Entitas.Generic;
+
+#pragma warning disable
+public class Entity_AddRemove_CompData_Struct_IncludeInit : IPerformanceTest
+{
+	private const			int						n						= 10000000;
+	private					Entity<TestScope1>		_ent;
+	public					int						Iterations				=> n;
+
+	public					void					Before					(  )
+	{
+		var contexts				= new Contexts(  );
+		contexts.AddScopedContexts(  );
+
+		var context					= contexts.Get<TestScope1>();
+		_ent						= context.CreateEntity();
+	}
+
+	public					void					Run						(  )
+	{
+		for ( var i = 0; i < n; i++ )
+		{
+			_ent.Add_( new TestCompAStruct_Scope1() {data = 5});
+			_ent.Remove_<TestCompAStruct_Scope1>(  );
+		}
+	}
+}

--- a/Tests/Tests_Performance/Sources/Fixtures/TestCompA_Scope1.cs
+++ b/Tests/Tests_Performance/Sources/Fixtures/TestCompA_Scope1.cs
@@ -5,6 +5,7 @@
 public sealed class TestCompA_Scope1 : IComponent
 		, Scope<TestScope1>
 		, ICompData
+    , ICreateApply
 		, ICopyFrom<TestCompA_Scope1>
 {
 	public Int32 data;
@@ -12,6 +13,12 @@ public sealed class TestCompA_Scope1 : IComponent
 	{
 		data = other.data;
 	}
+
+  public TestCompA_Scope1 Set(Int32 value)  // optional, allows using Cache<T>.I.Set(). Not needed for struct components
+  {
+    data = value;
+    return this;
+  }
 
 	public TestCompA_Scope1( Int32 data )
 	{

--- a/Tests/Tests_Performance/Tests_Performance.csproj
+++ b/Tests/Tests_Performance/Tests_Performance.csproj
@@ -44,9 +44,15 @@
         <Reference Include="System.Xml" />
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="MemoryHelper.cs" />
         <Compile Include="PerformanceTestsRunner.cs" />
         <Compile Include="Sources\EmptyTest.cs" />
+        <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Class_InitSet.cs" />
+        <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Class_CreateSetApply.cs" />
+        <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Class_AddNewInstance.cs" />
+        <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Class_SetUsingCache.cs" />
         <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Class_WithGroups.cs" />
+        <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Struct_IncludeInit.cs" />
         <Compile Include="Sources\Entity\Entity_AddRemove_CompData_Struct_WithGroups.cs" />
         <Compile Include="Sources\Entity\Entity_Flag_CompFlag.cs" />
         <Compile Include="Sources\Entity\Entity_Get_CompData_Class.cs" />


### PR DESCRIPTION
Change log:
1) add Init-Set syntax variant for component creation - this seams **10% faster and shorter syntax variant of Create-Set-Apply**

Full Create-component use-case syntax comparison:



a) entity.**Init**<TestComp_CreateApply_A>().**Set**(5);
b) entity.**Add**(**Cache**<TestComp_CreateApply_A>.I.**Set**(5));
c) entity.**Apply**(entity.**Create**<TestComp_CreateApply_A>().**Set**(5));
a.2) veryLongEntityVarName.**Init**<TestComp_CreateApply_A>().**Set**(5);
c.2) veryLongEntityVarName.**Apply**(veryLongEntityVarName.**Create**<TestComp_CreateApply_A>().**Set**(5));

Performance results:
![image](https://user-images.githubusercontent.com/8210414/98714002-07061000-2391-11eb-82b1-dd1359bc8d57.png)

2) **update StructComponent.ToString**

Entitas Observer (entities-debugger) will render Struct-Component.ToString in Entity.ToString:

![image](https://user-images.githubusercontent.com/8210414/98713363-32d4c600-2390-11eb-8f24-ea8f040ccaab.png)

3) **add more performance tests**
4) **update Readme**



